### PR TITLE
photoshop cc fixed

### DIFF
--- a/us-export-to-ios.jsx
+++ b/us-export-to-ios.jsx
@@ -28,6 +28,13 @@ init();
 
 // The other functions
 function init() {
+	// fix photoshop cc
+	// save current ruler unit settings, so we can restore it
+    	var ru = app.preferences.rulerUnits;
+    
+	// set ruler units to pixel to ensure scaling works as expected
+	app.preferences.rulerUnits = Units.PIXELS;    
+	
 	if(!isDocumentNew()) {
 		for(var dpi in scaleFactors) {
 			saveFunc(dpi);


### PR DESCRIPTION
photoshop cc was not working but repair it 
var ru = app.preferences.rulerUnits;
    
	// set ruler units to pixel to ensure scaling works as expected
	app.preferences.rulerUnits = Units.PIXELS;